### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ git clone https://github.com/udacity/CarND-Term1-Starter-Kit.git
 cd CarND-Term1-Starter-Kit
 conda env create -f environment.yml
 ```
+Verify that the carnd-term1 environment was created in your environments:
+```sh
+conda info --envs
+```
+If the carnd-term1 environment is not listed, make sure that the environment.yml file exists in your directory "..\\CarND-Term1-Starter-Kit". If it does not exist there, the previous conda command (conda env create -f environment.yml) won't create the carnd-term1 environment. You can manually add the environment.yml file by downloading it from the git repository (https://github.com/udacity/CarND-Term1-Starter-Kit/) using your browser and adding the file to the directory "..\\CarND-Term1-Starter-Kit". Perform the conda command "conda env create -f environment.yml" again if necessary.
 
 To use:
 


### PR DESCRIPTION
I found your readme this morning and followed it, Unfortunately, the "git clone https://github.com/udacity/CarND-Term1-Starter-Kit.git" command did not download the environment.yml file, so I could not execute the junyper notebook when it came to the thensorflow part. So I figured out that there is no carnd-term1 environment in my python environments, which was because I did not have the environment.yml file. 
For me as a beginner, it was hard to figure out the problem, and I can imagine there are many interested people who would not be able to figure out the problems themselves. Consequently, I propose to expand the readme file.