### PR TITLE
Patch for Windows Users

### DIFF
--- a/doc/configure_via_anaconda.md
+++ b/doc/configure_via_anaconda.md
@@ -37,16 +37,19 @@ Using Anaconda consists of the following:
 - **Mac:** http://conda.pydata.org/docs/install/quick.html#os-x-miniconda-install
 - **Windows:** http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install
 
-**Setup** your the `carnd-term1` environment. Running this command will create a new `conda` environment that is provisioned with all libraries you need to be successful in this program.
+**Setup** your the `carnd-term1` environment. 
 
 ```sh
 git clone https://github.com/udacity/CarND-Term1-Starter-Kit.git
 cd CarND-Term1-Starter-Kit
 ```
 
-If you are on Windows, rename `meta_windows_patch.yml` to `meta.yml`
+If you are on Windows, **rename**   
+`meta_windows_patch.yml` to   
+`meta.yml`
 
-``
+**Create** carnd-term1.  Running this command will create a new `conda` environment that is provisioned with all libraries you need to be successful in this program.
+```
 conda env create -f environment.yml
 ```
 

--- a/doc/configure_via_anaconda.md
+++ b/doc/configure_via_anaconda.md
@@ -42,6 +42,11 @@ Using Anaconda consists of the following:
 ```sh
 git clone https://github.com/udacity/CarND-Term1-Starter-Kit.git
 cd CarND-Term1-Starter-Kit
+```
+
+If you are on Windows, rename `meta_windows_patch.yml` to `meta.yml`
+
+``
 conda env create -f environment.yml
 ```
 

--- a/meta.yml
+++ b/meta.yml
@@ -1,2 +1,0 @@
-build:
-  ignore_prefix_files: True

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,2 @@
+build:
+  ignore_prefix_files: True

--- a/meta_windows_patch.yml
+++ b/meta_windows_patch.yml
@@ -1,0 +1,2 @@
+build:
+  ignore_prefix_files: True


### PR DESCRIPTION
Conda v 4.2 and up changed a default settings which causes install problems on many Windows machines.
`PaddingError`

This file restores the default setting of prior releases, to allow for proper install of many packages to windows.

This file is automatically run first in the build process, in order to allow for customized environment settings.

This file is ideally specifically to be run on Windows machines only (I dunno how to have the OS read  automatically, and only apply it to Windows machines).
Since it used to be the default setting, it might be fine to run it on linux or macos as well..
However...

Perhaps it's better to name the file something like `meta-windows_patch.yml`,
and have windows owners rename the file appropriately so that it gets run (but ignored otherwise)
