### PR TITLE
Specify version of imageio to download from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - flask-socketio
     - seaborn
     - pandas
-    - imageio
+    - imageio=2.1.2
     - pip:
         - moviepy
         - tensorflow


### PR DESCRIPTION
Specify version of imageio in order to download from conda-forge. This is required to make `imageio.plugins.ffmpeg.download()` work.

Should fix https://github.com/udacity/CarND-LaneLines-P1/issues/15. 