### PR TITLE
Add ffmpeg to the List of Packages to Install

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -2,8 +2,9 @@ FROM python:3.5.2
 
 MAINTAINER @joshuacook
 
-# Pick up some TF dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Pick up some TF dependencies (as a first step, add missed repos)
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         curl \
         libfreetype6-dev \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
         unzip \
         libgtk2.0-0 \
+        ffmpeg \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This fix resolves the known problem from project 1: `NeedDownloadError: Need ffmpeg exe.`

The workaround suggested in jupyter notebook (`You can download it by calling: 
imageio.plugins.ffmpeg.download()`) did not help me. The idea to install ffmpeg from repositories was taken from the following forum post: https://carnd-forums.udacity.com/display/CAR/questions/26218840/import-videofileclip-error.
