### PR TITLE
install ffmpeg in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
     - flask-socketio
     - seaborn
     - pandas
+    - ffmpeg
     - imageio=2.1.2
     - pip:
         - moviepy

--- a/ffmpeg.py
+++ b/ffmpeg.py
@@ -1,4 +1,0 @@
-#!/bin/python
-
-import imageio
-imageio.plugins.ffmpeg.download()


### PR DESCRIPTION
this commit fixes issue with ffmpeg mentioned here:   https://discussions.udacity.com/t/bug-report-incorrect-docker-image-name-on-18-run-some-code-in-term-1-lesson-2-finding-lane-lines/222955

ffmpeg have to be installed explicitly if old
version of imageio is used.

Removed obsolete ffmpeg.py