### PR TITLE
Fix to issue #74

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,10 @@ set -e
 
 if [ -z "$1" ]
   then
-    jupyter notebook 
+    jupyter notebook --allow-root
 elif [ "$1" == *".ipynb"* ]
   then
-    jupyter notebook "$1"
+    jupyter notebook "$1" --allow-root
 else
     exec "$@"
 fi


### PR DESCRIPTION
#74  As Jupyter notebooks are run as a root user in Docker, and this causesa  permission error. 
Tested with Jupyter version 4.3.0, where jupyter notebook was actually not even started without the --allow-root flag. 
This happens because Jupyter security model is constantly being tightened, and the warning is now an error for newer Jupyter versions.