### PR TITLE
Update configure_via_anaconda.md

### DIFF
--- a/doc/configure_via_anaconda.md
+++ b/doc/configure_via_anaconda.md
@@ -63,6 +63,12 @@ with
 ```yaml
     - https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.1-py3-none-any.whl
 ```
+If you have encountered a No module named 'requests' error, try to add in a line under 'pip' line in the environment.yml in a text editor
+
+with
+```yaml
+    - requests
+```
 
 **Verify** that the carnd-term1 environment was created in your environments:
 


### PR DESCRIPTION
Added instructions on including the 'requests' pip library as part of the Anaconda environment, as it seems missing and caused the "CarND-Term1-Starter-Kit-Test" github project unable to generate a video stream file.