### PR TITLE
Update environment-gpu.yml

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -10,6 +10,8 @@ dependencies:
     - opencv3
     - pillow
     - scikit-learn
+    - cudatoolkit==8.0
+    - cudnn==5.1
     - scikit-image
     - scipy
     - h5py


### PR DESCRIPTION
I figured out after struggling with my carnd-term1 env for 2 days, and found out that cuda 8.0 is required. Same problem occured in my aws instance and found installing cuda 8.0 and cudnn 5.1 resolved the errors. Here's the link to my issues:
https://discussions.udacity.com/t/tensorflow-problem-in-starter-kit-test/601283/9
https://discussions.udacity.com/t/receiving-aborted-core-dumped-error/695649/3