### PR TITLE
Avoid the build error

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -19,9 +19,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh tmp/Miniconda3-4.2.12-Linux-x86_64.sh
-RUN bash tmp/Miniconda3-4.2.12-Linux-x86_64.sh -b
+ADD https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh tmp/Miniconda3-4.5.4-Linux-x86_64.sh
+RUN bash tmp/Miniconda3-4.5.4-Linux-x86_64.sh -b
 ENV PATH $PATH:/root/miniconda3/bin/
+RUN conda update -n base conda -y 
 
 COPY environment.yml .
 RUN conda env create -f environment.yml

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ADD https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh tmp/Miniconda3-4.5.4-Linux-x86_64.sh
 RUN bash tmp/Miniconda3-4.5.4-Linux-x86_64.sh -b
 ENV PATH $PATH:/root/miniconda3/bin/
+RUN conda update -n base conda -y 
 
 COPY environment-gpu.yml  ./environment.yml
 RUN conda env create -f=environment.yml --name carnd-term1 --debug -v -v

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -18,13 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk2.0-0 \
         git \
 	tcl-dev \
-	tk-dev \	
+	tk-dev \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh tmp/Miniconda3-4.2.12-Linux-x86_64.sh
-RUN bash tmp/Miniconda3-4.2.12-Linux-x86_64.sh -b
+ADD https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh tmp/Miniconda3-4.5.4-Linux-x86_64.sh
+RUN bash tmp/Miniconda3-4.5.4-Linux-x86_64.sh -b
 ENV PATH $PATH:/root/miniconda3/bin/
 
 COPY environment-gpu.yml  ./environment.yml

--- a/Dockerfile.jupyterlab
+++ b/Dockerfile.jupyterlab
@@ -1,0 +1,23 @@
+# Set the base image use anaconda
+FROM continuumio/anaconda3
+
+# Set working directory
+WORKDIR /home/notebooks
+
+# Add requirements file
+ADD requirements.txt /app/
+
+# Installs, clean, and update
+RUN apt-get update \
+    && apt-get clean \
+    && apt-get update -qqq \
+    && apt-get install -y -q g++ \
+    && pip install --upgrade pip
+
+RUN pip install -r /app/requirements.txt \
+    && pip install -U tensorflow
+
+RUN pip install keras
+
+# Run shell command for notebook on start
+ENTRYPOINT ["jupyter", "lab", "--ip=0.0.0.0", "--allow-root"]

--- a/docker-compose-cpu.yml
+++ b/docker-compose-cpu.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  carnd:
+    build:
+      context: .
+      dockerfile: Dockerfile.cpu
+
+    ports:
+      - '8888:8888'

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+    carnd-starter-kit:
+        build:
+            context: .
+            dockerfile: Dockerfile.gpu
+        ports:
+            - '8888:8888'

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -1,7 +1,7 @@
 version: '2'
 
 services:
-    carnd-starter-kit:
+    gpu:
         build:
             context: .
             dockerfile: Dockerfile.gpu

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -7,6 +7,7 @@ dependencies:
     - numpy
     - matplotlib
     - jupyter
+    - jupyterlab
     - opencv3
     - pillow
     - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
     - numpy
     - matplotlib
     - jupyter
+    - jupyterlab
     - opencv3
     - pillow
     - scikit-learn

--- a/run.sh
+++ b/run.sh
@@ -4,11 +4,10 @@ set -e
 
 if [ -z "$1" ]
   then
-    jupyter notebook --allow-root
+    jupyter lab --allow-root
 elif [ "$1" == *".ipynb"* ]
   then
-    jupyter notebook "$1" --allow-root
+    jupyter lab "$1" --allow-root
 else
     exec "$@"
 fi
-


### PR DESCRIPTION
Hi Udacity,

To use the lastest conda is necessary to succeed the build. 
Referring to the open issue: https://github.com/udacity/CarND-Term1-Starter-Kit/issues/99

Add RUN `conda update -n base conda -y` is necessary in both cpu and gpu file.