### PR TITLE
Jupyter config is broken: ip='*' has been removed

### DIFF
--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,7 +1,7 @@
 import os
 from IPython.lib import passwd
 
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = int(os.getenv('PORT', 8888))
 c.NotebookApp.open_browser = False
 c.MultiKernelManager.default_kernel_name = 'python'


### PR DESCRIPTION
Pulling the latests Docker cpu image and running it results in the following error: 

```
Traceback (most recent call last):
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 869, in _default_allow_remote
    addr = ipaddress.ip_address(self.ip)
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/ipaddress.py", line 54, in ip_address
    address)
ValueError: '' does not appear to be an IPv4 or IPv6 address

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/miniconda3/envs/carnd-term1/bin/jupyter-notebook", line 11, in <module>
    sys.exit(main())
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/traitlets/config/application.py", line 657, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-7>", line 2, in initialize
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 1629, in initialize
    self.init_webapp()
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 1379, in init_webapp
    self.jinja_environment_options,
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 158, in __init__
    default_url, settings_overrides, jinja_env_options)
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 251, in init_settings
    allow_remote_access=jupyter_app.allow_remote_access,
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/traitlets/traitlets.py", line 556, in __get__
    return self.get(obj, cls)
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/traitlets/traitlets.py", line 535, in get
    value = self._validate(obj, dynamic_default())
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/site-packages/notebook/notebookapp.py", line 872, in _default_allow_remote
    for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
  File "/root/miniconda3/envs/carnd-term1/lib/python3.5/socket.py", line 732, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known
```

This is probably also the case for the GPU image. This comes from a breaking change introduced in a dependency of Jupyter which has not yet been fixed, see [this thread](https://github.com/jupyter/docker-stacks/issues/718).

This pull requests fixes the problem using `ip='0.0.0.0'` rather the now broken than `ip='*'` option.

Until this gets merged, those that want to use the local installation to work on their projects can use the following workaround:

- Run the docker image as usual, but appending the `bash` command to open a terminal:
`docker run --init -it --rm -p 8888:8888 -v `pwd`:/src udacity/carnd-term1-starter-kit bash`

- Edit the `jupyter_notebook_config.py` file directly
`sed -i "s/c.NotebookApp.ip = '\*'/c.NotebookApp.ip = '0.0.0.0'/" /root/.jupyter/jupyter_notebook_config.py`

- Run the notebook server: `nohup /run.sh &` (and then "ENTER" twice)
- Copy the token from the output of: `cat nohup.out`
- Detach from the docker terminal using ctrl+P then ctrl+Q.
- To shutdown the notebook when you're done, use `docker stop <docker_pid>` where `docker_pid` is retrieved from `docker ps`.


