### PR TITLE
Remove imageio version pinning

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -17,7 +17,7 @@ dependencies:
     - seaborn
     - pandas
     - ffmpeg
-    - imageio=2.1.2
+    - imageio
     - pyqt=4.11.4
     - pip:
         - moviepy

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - seaborn
     - pandas
     - ffmpeg
-    - imageio=2.1.2
+    - imageio
     - pyqt=4.11.4
     - pip:
         - moviepy


### PR DESCRIPTION
A conflict exists in the current packaging configuration that prevents imageio from installing successfully, meaning opencv2 isn't available. Remove the version pinning for imageio resolves the conflict.

I tested on multiple instances (2x VMs and a Miniconda docker container) that the current version of the environment.yml fails to fully install the appropriate packages, resulting in an error when importing cv2. I've confirmed that with my change, I was able to initialize the environment as described in the readme and import cv2.