### PR TITLE
update python and pyqt version pinning

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -3,7 +3,7 @@ channels:
     - https://conda.anaconda.org/menpo
     - conda-forge
 dependencies:
-    - python==3.5.2
+    - python==3.6.3
     - numpy
     - matplotlib
     - jupyter
@@ -18,7 +18,7 @@ dependencies:
     - pandas
     - ffmpeg
     - imageio
-    - pyqt=4.11.4
+    - pyqt=5.6.0
     - pip:
         - moviepy
         - opencv-python

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - https://conda.anaconda.org/menpo
     - conda-forge
 dependencies:
-    - python==3.5.2
+    - python==3.6.3
     - numpy
     - matplotlib
     - jupyter
@@ -18,7 +18,7 @@ dependencies:
     - pandas
     - ffmpeg
     - imageio
-    - pyqt=4.11.4
+    - pyqt=5.6.0
     - pip:
         - moviepy
         - opencv-python


### PR DESCRIPTION
Tried installing natively (on both my mac and my linux machines) from the previous environment.yml file but always ran into conflicts. Eventually found out it was because of python 3.5.2. So I double-checked against the versions of the packages that were running on the Udacity workspace, and thought that updating the file here could save future CarND students some time. :)